### PR TITLE
Fix ToC items after scrolling down

### DIFF
--- a/docs/stylesheets/dark_theme.css
+++ b/docs/stylesheets/dark_theme.css
@@ -80,6 +80,10 @@ Arrow Right Icon
   background-color: #212121 !important;
 }
 
+.md-nav__link[data-md-state=blur] {
+  color: rgba(255,255,255,0.54) !important;
+}
+
 /*
 ////////////
 // Search //


### PR DESCRIPTION
Hey, I recently added this to my wiki and found that the styling was a bit broken in one small place; the table of contents items after scrolling down a ways:

Before fix:
![chrome_VZR9rlaK5l](https://user-images.githubusercontent.com/2432634/65358571-2f441580-dbb7-11e9-9df7-9825841fbe6a.png)

After fix:
![chrome_5kiYEve8yn](https://user-images.githubusercontent.com/2432634/65358583-35d28d00-dbb7-11e9-9f92-9b643379d4ae.png)
