### PR TITLE
Fix blockquote colors

### DIFF
--- a/docs/stylesheets/dark_theme.css
+++ b/docs/stylesheets/dark_theme.css
@@ -32,6 +32,14 @@ tbody {
 }
 
 /*
+Blockquotes
+*/
+.md-typeset blockquote {
+  color: rgba(255,255,255,0.8) !important;
+  border-color: rgba(255,255,255,0.54) !important;
+}
+
+/*
 ////////////////////
 // Navigation bar //
 ////////////////////


### PR DESCRIPTION
Hey, another fix for an issue I found on my team's wiki:

Blockquotes before fix:

![chrome_MtEFMF6kaB](https://user-images.githubusercontent.com/2432634/66069078-e91e7880-e50b-11e9-8b18-e13adfc0a427.png)

Blockquotes after fix:

![chrome_g9fjDbTUUb](https://user-images.githubusercontent.com/2432634/66069103-efacf000-e50b-11e9-898a-d2884ad14e44.png)