### PR TITLE
Made inline code styles more readable

### DIFF
--- a/docs/stylesheets/codehilite.css
+++ b/docs/stylesheets/codehilite.css
@@ -5,7 +5,11 @@
 */
 
 .md-typeset code {
-  color: black !important
+  background-color: #424242;
+  color: #F5F5F5;
+  margin: 0;
+  padding: 0.07353em 0.29412em;
+  box-shadow: none;
 }
 
 /*


### PR DESCRIPTION
Improvement to inline code styles:

Before:
![004-chrome_Id2QWhUV1K](https://user-images.githubusercontent.com/2432634/67046488-891ff880-f0ed-11e9-9f6f-1813d6553fe4.png)

After:
![005-chrome_EE8HjwaepY](https://user-images.githubusercontent.com/2432634/67046515-9b019b80-f0ed-11e9-954b-867f949e76a4.png)
